### PR TITLE
Add support for Summer mode and hot water lock in buildSetBoilerStatusRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This library provides implementation of OpenTherm protocol.
 
 OpenTherm Library is based on OpenTherm protocol specification v2.2 and works with all OpenTherm compatible boilers. Library can be easily installed into Arduino IDE and compiled for Arduino, ESP8266 and other similar controllers. 
 
+This fork contains a few commands from later OpenTherm protocol specifications.
+
 OpenTherm protocol requires simple low voltage twowire connection to boiler, but voltage levels (7..15V) still much higher than Arduino/ESP8266 levels, which requires [OpenTherm Adapter](http://ihormelnyk.com/opentherm_adapter).
 
 This version of library uses interrupts to achieve better stability and synchronization with boiler.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenTherm Library
-version=1.1.4
+version=1.1.4a
 author=Ihor Melnyk <ihor.melnyk@gmail.com>
 maintainer=Ihor Melnyk <ihor.melnyk@gmail.com>
 sentence=OpenTherm Library for HVAC system control communication using Arduino and ESP8266/ESP32 hardware.

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -259,14 +259,14 @@ bool OpenTherm::isValidResponse(unsigned long response)
 {
 	if (parity(response)) return false;
 	byte msgType = (response << 1) >> 29;
-	return msgType == READ_ACK || msgType == WRITE_ACK;
+	return msgType == (byte) OpenThermMessageType::READ_ACK || msgType == (byte) OpenThermMessageType::WRITE_ACK;
 }
 
 bool OpenTherm::isValidRequest(unsigned long request)
 {
 	if (parity(request)) return false;
 	byte msgType = (request << 1) >> 29;
-	return msgType == READ_DATA || msgType == WRITE_DATA;
+	return msgType == (byte) OpenThermMessageType::READ_DATA || msgType == (byte) OpenThermMessageType::WRITE_DATA;
 }
 
 void OpenTherm::end() {
@@ -278,26 +278,26 @@ void OpenTherm::end() {
 const char *OpenTherm::statusToString(OpenThermResponseStatus status)
 {
 	switch (status) {
-		case NONE:	return "NONE";
-		case SUCCESS: return "SUCCESS";
-		case INVALID: return "INVALID";
-		case TIMEOUT: return "TIMEOUT";
-		default:	  return "UNKNOWN";
+		case OpenThermResponseStatus::NONE:	   return "NONE";
+		case OpenThermResponseStatus::SUCCESS: return "SUCCESS";
+		case OpenThermResponseStatus::INVALID: return "INVALID";
+		case OpenThermResponseStatus::TIMEOUT: return "TIMEOUT";
+		default:	                           return "UNKNOWN";
 	}
 }
 
 const char *OpenTherm::messageTypeToString(OpenThermMessageType message_type)
 {
 	switch (message_type) {
-		case READ_DATA:	   return "READ_DATA";
-		case WRITE_DATA:	  return "WRITE_DATA";
-		case INVALID_DATA:	return "INVALID_DATA";
-		case RESERVED:		return "RESERVED";
-		case READ_ACK:		return "READ_ACK";
-		case WRITE_ACK:	   return "WRITE_ACK";
-		case DATA_INVALID:	return "DATA_INVALID";
-		case UNKNOWN_DATA_ID: return "UNKNOWN_DATA_ID";
-		default:			  return "UNKNOWN";
+		case OpenThermMessageType::READ_DATA:	    return "READ_DATA";
+		case OpenThermMessageType::WRITE_DATA:	    return "WRITE_DATA";
+		case OpenThermMessageType::INVALID_DATA:	return "INVALID_DATA";
+		case OpenThermMessageType::RESERVED:		return "RESERVED";
+		case OpenThermMessageType::READ_ACK:		return "READ_ACK";
+		case OpenThermMessageType::WRITE_ACK:	    return "WRITE_ACK";
+		case OpenThermMessageType::DATA_INVALID:	return "DATA_INVALID";
+		case OpenThermMessageType::UNKNOWN_DATA_ID: return "UNKNOWN_DATA_ID";
+		default:			                        return "UNKNOWN";
 	}
 }
 

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -303,8 +303,8 @@ const char *OpenTherm::messageTypeToString(OpenThermMessageType message_type)
 
 //building requests
 
-unsigned long OpenTherm::buildSetBoilerStatusRequest(bool enableCentralHeating, bool enableHotWater, bool enableCooling, bool enableOutsideTemperatureCompensation, bool enableCentralHeating2) {
-	unsigned int data = enableCentralHeating | (enableHotWater << 1) | (enableCooling << 2) | (enableOutsideTemperatureCompensation << 3) | (enableCentralHeating2 << 4);
+unsigned long OpenTherm::buildSetBoilerStatusRequest(bool enableCentralHeating, bool enableHotWater, bool enableCooling, bool enableOutsideTemperatureCompensation, bool enableCentralHeating2,bool enableSummerMode, bool lockHotWater) {
+	unsigned int data = enableCentralHeating | (enableHotWater << 1) | (enableCooling << 2) | (enableOutsideTemperatureCompensation << 3) | (enableCentralHeating2 << 4) | (enableSummerMode << 5) | (lockHotWater << 6);
 	data <<= 8;
 	return buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::Status, data);
 }

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -141,7 +141,7 @@ public:
 	bool isValidResponse(unsigned long response);
 
 	//requests
-	unsigned long buildSetBoilerStatusRequest(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);
+	unsigned long buildSetBoilerStatusRequest(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false, bool enableSummerMode = false, bool lockHotWater = false);
 	unsigned long buildSetBoilerTemperatureRequest(float temperature);
 	unsigned long buildGetBoilerTemperatureRequest();
 

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -16,7 +16,7 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #include <stdint.h>
 #include <Arduino.h>
 
-enum OpenThermResponseStatus {
+enum class OpenThermResponseStatus {
 	NONE,
 	SUCCESS,
 	INVALID,
@@ -24,7 +24,7 @@ enum OpenThermResponseStatus {
 };
 
 
-enum OpenThermMessageType {
+enum class OpenThermMessageType {
 	/*  Master to Slave */
 	READ_DATA       = B000,
 	READ            = READ_DATA, // for backwared compatibility
@@ -41,7 +41,7 @@ enum OpenThermMessageType {
 
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility
 
-enum OpenThermMessageID {
+enum class OpenThermMessageID {
 	Status, // flag8 / flag8  Master and Slave Status flags.
 	TSet, // f8.8  Control setpoint  ie CH  water temperature setpoint (°C)
 	MConfigMMemberIDcode, // flag8 / u8  Master Configuration Flags /  Master MemberID Code
@@ -101,7 +101,7 @@ enum OpenThermMessageID {
 	SlaveVersion, // u8 / u8  Slave product version number and type
 };
 
-enum OpenThermStatus {
+enum class OpenThermStatus {
 	NOT_INITIALIZED,
 	READY,
 	DELAY,

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -16,7 +16,7 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #include <stdint.h>
 #include <Arduino.h>
 
-enum class OpenThermResponseStatus {
+enum class OpenThermResponseStatus : byte {
 	NONE,
 	SUCCESS,
 	INVALID,
@@ -24,7 +24,7 @@ enum class OpenThermResponseStatus {
 };
 
 
-enum class OpenThermMessageType {
+enum class OpenThermMessageType : byte {
 	/*  Master to Slave */
 	READ_DATA       = B000,
 	READ            = READ_DATA, // for backwared compatibility
@@ -41,7 +41,7 @@ enum class OpenThermMessageType {
 
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility
 
-enum class OpenThermMessageID {
+enum class OpenThermMessageID : byte {
 	Status, // flag8 / flag8  Master and Slave Status flags.
 	TSet, // f8.8  Control setpoint  ie CH  water temperature setpoint (°C)
 	MConfigMMemberIDcode, // flag8 / u8  Master Configuration Flags /  Master MemberID Code
@@ -101,7 +101,7 @@ enum class OpenThermMessageID {
 	SlaveVersion, // u8 / u8  Slave product version number and type
 };
 
-enum class OpenThermStatus {
+enum class OpenThermStatus : byte {
 	NOT_INITIALIZED,
 	READY,
 	DELAY,

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -76,6 +76,9 @@ enum OpenThermMessageID {
 	TflowCH2, // f8.8  Flow water temperature CH2 circuit (°C)
 	Tdhw2, // f8.8  Domestic hot water temperature 2 (°C)
 	Texhaust, // s16  Boiler exhaust temperature (°C)
+	TheatExchanger, // f8.8 Boiler heat exchanger temperature
+	BoilerFanSpeed = 35, // u16 Boiler fan speed setpoint & actual
+	BoilerFlameCurrent, // (f8.8 ?) Current through burner flame (uA)
 	TdhwSetUBTdhwSetLB = 48, // s8 / s8  DHW setpoint upper & lower bounds for adjustment  (°C)
 	MaxTSetUBMaxTSetLB, // s8 / s8  Max CH water setpoint upper & lower bounds for adjustment  (°C)
 	HcratioUBHcratioLB, // s8 / s8  OTC heat curve ratio upper & lower bounds for adjustment


### PR DESCRIPTION
Hi,
I've slightly modified buildSetBoilerStatusRequest to add support for Summer Mode and Hot Water Lock as per OpenTherm function Matrix.
The default bool values are both false, so Backwards compatibility is preserved.

Thanks for your work supporting this library!